### PR TITLE
Adds support for prefers reduced motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updated [stylelint-scss](https://github.com/kristerkari/stylelint-scss) from `1.4.x` to `^2.0.1`
 * Replaced deprecated `scss/at-mixin-no-argumentless-call-parentheses` rule with its equivalent `scss/at-mixin-argumentless-call-parentheses`
 * Updated `eslint-plugin-shopify` to the latest version, and updated ESLint to the appropriate version
+* Updates `media-feature-name-no-unknown` to ignore `prefers-reduced-motion`
 
 ## [2.0.1] - 2017-07-28
 

--- a/rules/media.js
+++ b/rules/media.js
@@ -10,7 +10,9 @@ module.exports = {
   // Specify lowercase or uppercase for media feature names.
   'media-feature-name-case': 'lower',
   // Disallow unknown media feature names.
-  'media-feature-name-no-unknown': true,
+  'media-feature-name-no-unknown': [true, {
+    ignoreMediaFeatureNames: ['prefers-reduced-motion'],
+  }],
   // Disallow vendor prefixes for media feature names.
   'media-feature-name-no-vendor-prefix': true,
   // Specify a whitelist of allowed media feature names


### PR DESCRIPTION
This PR adds the ability to use the `prefers-reduced-motion` user query. https://github.com/Shopify/assets/pull/889 is currently blocked until this fix is merged. 

I'm not sure how to check if this is working correctly. [Here are the docs I followed for adding this.](https://stylelint.io/user-guide/rules/media-feature-name-no-unknown/#optional-secondary-options)