### PR TITLE
Allow stylelint@8.1.x peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "eslint-plugin-shopify": "^17.1.0"
   },
   "peerDependencies": {
-    "stylelint": "8.0.x"
+    "stylelint": ">=8.0 <=8.1"
   }
 }


### PR DESCRIPTION
[sewing-kit requires stylelint@8.1](https://github.com/Shopify/sewing-kit/issues/335).  

The [8.1 CHANGELOG](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md#811) contains a new CLI flag, rule fixes, and autofixes.  Nothing concerning there.