### PR TITLE
Remove `position: fixed` from the blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Test this new release with:
 yarn add --dev stylelint-config-shopify@next
 ```
 
+- Removed `position: fixed` from the property value blacklist, see [#18](https://github.com/Shopify/stylelint-config-shopify/pull/18)
 - Allowed digits in class selector names (e.g. `.rotate180`), see [#17](https://github.com/Shopify/stylelint-config-shopify/pull/17)
 - Enforce property grouping, see [#10](https://github.com/Shopify/stylelint-config-shopify/pull/10)
 

--- a/rules/declaration.js
+++ b/rules/declaration.js
@@ -41,7 +41,6 @@ module.exports = {
   'declaration-property-unit-whitelist': null,
   // Specify a blacklist of disallowed property and value pairs within declarations.
   'declaration-property-value-blacklist': {
-    position: ['fixed'],
     '/^animation/': ['linear'],
   },
   // Specify a whitelist of allowed property and value pairs within declarations.


### PR DESCRIPTION
This rule doesn't make sense depending on how the project is structured, so it doesn't make sense to enforce it in a shared config.

Instead, individual projects should be enforcing it if they deem it necessary.