### PR TITLE
Turn off order/order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ yarn add --dev stylelint-config-shopify@next
 - Removed `position: fixed` from the property value blacklist, see [#18](https://github.com/Shopify/stylelint-config-shopify/pull/18)
 - Allowed digits in class selector names (e.g. `.rotate180`), see [#17](https://github.com/Shopify/stylelint-config-shopify/pull/17)
 - Enforce property grouping, see [#10](https://github.com/Shopify/stylelint-config-shopify/pull/10)
+- Turn off `order/order`
 
 ### tl;dr
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ yarn add --dev stylelint-config-shopify@next
 - Removed `position: fixed` from the property value blacklist, see [#18](https://github.com/Shopify/stylelint-config-shopify/pull/18)
 - Allowed digits in class selector names (e.g. `.rotate180`), see [#17](https://github.com/Shopify/stylelint-config-shopify/pull/17)
 - Enforce property grouping, see [#10](https://github.com/Shopify/stylelint-config-shopify/pull/10)
-- Turn off `order/order`
+- Turn off `order/order` [#19](https://github.com/Shopify/stylelint-config-shopify/pull/19)
 
 ### tl;dr
 

--- a/rules/order.js
+++ b/rules/order.js
@@ -1,7 +1,7 @@
 module.exports = {
   // https://github.com/hudochenkov/stylelint-order/tree/master/rules/order
   // Force variables to be at the top
-  'order/order': ['custom-properties', 'dollar-variables'],
+  'order/order': null,
 
   // https://github.com/hudochenkov/stylelint-order/tree/master/rules/properties-order
   // Order inspired by Concentric CSS http://rhodesmill.org/brandon/2011/concentric-css/


### PR DESCRIPTION
There currently is a bug in the fixer for `order/order`. See [here](https://github.com/hudochenkov/stylelint-order/issues/51) for more details. 

This may lead to unexpected scss behavior when onboarding a new code base to `shopify-stylelint-config`. It's best to keep this off until https://github.com/hudochenkov/stylelint-order/issues/51 is resolved. 