### PR TITLE
Allow longhand CSS grid properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- ## [Unreleased] -->
 
+* `declaration-block-no-redundant-longhand-properties` now allows longhand `grid` properties, see [#21](https://github.com/Shopify/stylelint-config-shopify/pull/21)
+
 ## [3.0.1] - 2017-11-13
 
 - Removed `position: fixed` from the property value blacklist, see [#18](https://github.com/Shopify/stylelint-config-shopify/pull/18)

--- a/rules/declaration.js
+++ b/rules/declaration.js
@@ -4,7 +4,9 @@ module.exports = {
     ignore: 'consecutive-duplicates',
   }],
   // Disallow longhand properties that can be combined into one shorthand property.
-  'declaration-block-no-redundant-longhand-properties': true,
+  'declaration-block-no-redundant-longhand-properties': [true, {
+    ignoreShorthands: ['/^grid.*/'],
+  }],
   // Disallow shorthand properties that override related longhand properties within declaration blocks.
   'declaration-block-no-shorthand-property-overrides': true,
   // Require a newline or disallow whitespace after the semicolons of declaration blocks.


### PR DESCRIPTION
The shorthand properties pack a lot of information into a small space.  IMO, it's easier for people to understand (or Google) separate concerns (section layout, column sizing, row sizing).

This came up in [a shopify/web PR](https://github.com/Shopify/web/pull/1833/files#r150669944), and I'd really like to see what others think.

With shorthand:
```css
 grid:
    'topBar topBar' auto
    'nav main' 1fr
    'banners banners' auto
    / auto 1fr;
```

With longhand:
```css
  grid-template-areas:
    'topBar topBar' 
    'nav main' 
    'banners banners';
  grid-template-columns: auto 1fr;
  grid-template-rows: 
    auto 
    1fr 
    auto;
```

cc @Shopify/css 