### PR TITLE
Disable `content-no-strings` rule by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [5.1.1] - 2018-07-09
 - Rename `plugin/content-no-strings` rule to `shopify/content-no-strings`.
+- Disable `shopify/content-no-strings` by default.
 
 ## [5.1.0] - 2018-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 <!-- ## [Unreleased] -->
 
-## [5.1.1] - 2018-07-09
-- Rename `plugin/content-no-strings` rule to `shopify/content-no-strings`.
-- Disable `shopify/content-no-strings` by default.
+## [5.1.1] - 2018-07-10
 
-## [5.1.0] - 2018-07-05
-
-- Added a new custom rule `plugin/content-no-strings` that disallows hard-coded strings as values for the `content` property. This prevents internationalization issues. Keywords are still allowed.
+- Added a new custom rule `shopify/content-no-strings` that disallows hard-coded strings as values for the `content` property. This prevents internationalization issues. Keywords are still allowed. The rule is not enabled by default. 
 
 The following patterns are considered violations:
 
@@ -29,6 +25,10 @@ The following patterns are _not_ considered violations:
 ```css
 .foo::before { content: open-quote counter(section_counter) close-quote; }
 ```
+
+## [5.1.0] - 2018-07-05 [YANKED]
+
+- Use 5.1.1 instead.
 
 ## [5.0.1] - 2018-04-06
 
@@ -172,7 +172,8 @@ property: <top> <right> <bottom> <left>
 * Initial release
 
 
-[Unreleased]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.1.0...HEAD
+[Unreleased]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.1.1...HEAD
+[5.1.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v4.0.0...v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 <!-- ## [Unreleased] -->
 
+## [5.1.1] - 2018-07-09
+- Rename `plugin/content-no-strings` rule to `shopify/content-no-strings`.
+
 ## [5.1.0] - 2018-07-05
 
 - Added a new custom rule `plugin/content-no-strings` that disallows hard-coded strings as values for the `content` property. This prevents internationalization issues. Keywords are still allowed.

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
     require('./rules/unit'),
     require('./rules/value'),
     {
-      'plugin/content-no-strings': true,
+      'shopify/content-no-strings': true,
     },
   ),
 };

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
     require('./rules/unit'),
     require('./rules/value'),
     {
-      'shopify/content-no-strings': true,
+      'shopify/content-no-strings': null,
     },
   ),
 };

--- a/plugins/content-no-strings/content-no-strings.js
+++ b/plugins/content-no-strings/content-no-strings.js
@@ -1,6 +1,6 @@
 const stylelint = require('stylelint');
 
-const ruleName = 'plugin/content-no-strings';
+const ruleName = 'shopify/content-no-strings';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: 'You must not hard-code unlocalized strings into the `content` property',

--- a/plugins/content-no-strings/content-no-strings.test.js
+++ b/plugins/content-no-strings/content-no-strings.test.js
@@ -1,8 +1,8 @@
 const testRule = require('stylelint-test-rule-tape');
-const shopifyi18n = require('.');
+const contentNoStrings = require('.');
 
-testRule(shopifyi18n.rule, {
-  ruleName: shopifyi18n.ruleName,
+testRule(contentNoStrings.rule, {
+  ruleName: contentNoStrings.ruleName,
   config: true,
   skipBasicChecks: true,
 


### PR DESCRIPTION
It makes more sense to have projects opt into the rule given that it's specific to projects that are being localized.

Also, renamed the rule to `shopify/content-no-strings` to show that it's a Shopify rule (for now). The stylelint guide recommends the `plugin/` prefix but that feels like an antipattern to me. 