### PR TITLE
Use stylelint-prettier in prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Changed dependency: Use `stylelint-prettier` for prettier integration instead of `prettier-stylelint-formatter`. `stylelint-prettier` is stylelint plugin that exposes prettier issues as stylelint rule violations. This means you can use `stylelint --fix` to fix formatting issues that prettier raises instead of having to use different executables for showing and autofixing issues.
+- Changed dependency: Use `stylelint-prettier` for prettier integration instead of `prettier-stylelint-formatter`. `stylelint-prettier` is a stylelint plugin that exposes prettier issues as stylelint rule violations. This means you can use `stylelint --fix` to fix formatting issues that prettier raises instead of having to use different executables for showing and autofixing issues.
 
 ### Migration Suggestions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Changed dependency: Use `stylelint-prettier` for prettier integration instead of `prettier-stylelint-formatter`. `stylelint-prettier` is stylelint plugin that exposes prettier issues as stylelint rule violations. This means you can use `stylelint --fix` to fix formatting issues that prettier raises instead of having to use different executables for showing and autofixing issues.
+
+### Migration Suggestions
+
+- If `stylelint-config-shopify/prettier` is used, please remove `prettier-stylelint-formatter` and update any scripts that referenced it to use run `stylelint --fix '**/*.scss'` to autofix issues.
+
+  ```
+  yarn remove prettier-stylelint-formatter
+  ```
+
 ## [5.1.2] - 2018-07-10
 
 - Changed dependency: Pull the base prettier config from stylelint-config-prettier instead of  prettier-stylelint-formatter. It is provided by the prettier organisation and is more up to date than the one provided by prettier-stylelint-formatter

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run stylelint
 ## Prettier
 
 This config also includes a prettier config which can be extended to format `.scss`.
-Using the `stylelint-prettier` plugin, prettier changes are exposed as stylelint rule violations.
+Using the [`stylelint-prettier`](https://github.com/bpscott/stylelint-prettier) plugin, prettier changes are exposed as stylelint rule violations.
 
 Install [`prettier`](https://github.com/prettier/prettier):
 
@@ -75,3 +75,5 @@ Add a prettier config in `package.json`:
   "bracketSpacing": false
 }
 ```
+
+Prettier fixes shall be reported when you run `stylelint **/*.css` and shall be autofixed when you run `stylelint --fix **/*.scss`.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ npm run stylelint
 ## Prettier
 
 This config also includes a prettier config which can be extended to format `.scss`.
+Using the `stylelint-prettier` plugin, prettier changes are exposed as stylelint rule violations.
 
-Install [`prettier-stylelint-formatter`](https://github.com/ismail-syed/prettier-stylelint-formatter):
+Install [`prettier`](https://github.com/prettier/prettier):
 
 ```
-$ yarn add --dev prettier-stylelint-formatter
+$ yarn add --dev prettier
 ```
 
 Extend the config in your `package.json`:
@@ -73,10 +74,4 @@ Add a prettier config in `package.json`:
   "trailingComma": "es5",
   "bracketSpacing": false
 }
-```
-
-Run `prettier-stylelint`:
-
-```
-prettier-stylelint **/*.scss
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-shopify",
-  "version": "5.1.2",
+  "version": "6.0.0-stylelint-prettier-beta.1",
   "description": "Shopify's stylelint rules and config",
   "main": "index.js",
   "repository": {
@@ -37,6 +37,7 @@
     "merge": "1.2.x",
     "stylelint-config-prettier": "^3.3.0",
     "stylelint-order": "~0.8.1",
+    "stylelint-prettier": "^0.2.1",
     "stylelint-scss": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "merge": "1.2.x",
     "stylelint-config-prettier": "^3.3.0",
     "stylelint-order": "~0.8.1",
-    "stylelint-prettier": "^0.2.1",
+    "stylelint-prettier": "^0.2.2",
     "stylelint-scss": "^3.0.0"
   },
   "devDependencies": {

--- a/prettier.js
+++ b/prettier.js
@@ -1,11 +1,14 @@
 module.exports = {
+  plugins: [
+    'stylelint-prettier',
+  ],
   extends: [
     './index',
     'stylelint-config-prettier',
   ],
-
-  // conflicts with prettier formatting
   rules: {
+    'prettier/prettier': true,
+    // conflicts with prettier formatting
     'scss/double-slash-comment-empty-line-before': null,
     'scss/operator-no-newline-after': null,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,6 +1030,13 @@ eslint-plugin-prettier@2.6.0:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+eslint-plugin-prettier@^2.1.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 eslint-plugin-promise@3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz#f4bde5c2c77cdd69557a8f69a24d1ad3cfc9e67e"
@@ -3351,6 +3358,12 @@ stylelint-order@~0.8.1:
     lodash "^4.17.4"
     postcss "^6.0.14"
     postcss-sorting "^3.1.0"
+
+stylelint-prettier@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-0.2.1.tgz#8a2d0057bb869933ee87612e525e13f1fb3fc76c"
+  dependencies:
+    eslint-plugin-prettier "^2.1.0"
 
 stylelint-scss@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,7 +1030,7 @@ eslint-plugin-prettier@2.6.0:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
-eslint-plugin-prettier@^2.1.0:
+eslint-plugin-prettier@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
   dependencies:
@@ -3359,11 +3359,11 @@ stylelint-order@~0.8.1:
     postcss "^6.0.14"
     postcss-sorting "^3.1.0"
 
-stylelint-prettier@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-0.2.1.tgz#8a2d0057bb869933ee87612e525e13f1fb3fc76c"
+stylelint-prettier@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-0.2.2.tgz#85df8194f19523a7e23edab2ddc90bea79bc5110"
   dependencies:
-    eslint-plugin-prettier "^2.1.0"
+    eslint-plugin-prettier "^2.6.2"
 
 stylelint-scss@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
stylelint-prettier runs prettier transforms as a stylelint plugin. This
means that you can do `stylelint foo.css --fix` and format the file
as prettier would.

This removes the need for having to run (s)css files through prettier
then through stylelint to get fully formatted output (such as using
prettier-stylelint-formatter). This is in line with how our eslint
prettier config allows us to run `eslint foo.js --fix` to prettify the
content as part of an eslint rule.