### PR TITLE
Update stylelint-config-prettier to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "merge": "1.2.x",
-    "stylelint-config-prettier": "^3.3.0",
+    "stylelint-config-prettier": "^4.0.0",
     "stylelint-order": "~0.8.1",
     "stylelint-prettier": "^0.2.2",
     "stylelint-scss": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3345,11 +3345,9 @@ stylehacks@^2.3.0:
     text-table "^0.2.0"
     write-file-stdout "0.0.2"
 
-stylelint-config-prettier@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-3.3.0.tgz#cc22a4b5310c1919cee77131d6e220c60a62a480"
-  dependencies:
-    stylelint "^9.1.1"
+stylelint-config-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-4.0.0.tgz#8c712977be13bd25191ab8b986b5c07a3342a5dc"
 
 stylelint-order@~0.8.1:
   version "0.8.1"


### PR DESCRIPTION
The code is identical to v3.3.0 except it moves stylelint to be a
peerDependency, which means there is less chance for conflicting
versions