### PR TITLE
Update to latest stylelint-prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Updated stylelint-prettier to v1.0.1 ([#42](https://github.com/Shopify/stylelint-config-shopify/pull/42))
 
 ## [7.0.0] - 2018-08-30
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "merge": "1.2.x",
     "stylelint-config-prettier": "^4.0.0",
     "stylelint-order": "1.0.0",
-    "stylelint-prettier": "^0.2.2",
+    "stylelint-prettier": "1.0.1",
     "stylelint-scss": "3.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3406,9 +3406,9 @@ stylelint-order@1.0.0:
     postcss "^7.0.2"
     postcss-sorting "^4.0.0"
 
-stylelint-prettier@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-0.2.2.tgz#85df8194f19523a7e23edab2ddc90bea79bc5110"
+stylelint-prettier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.0.1.tgz#991f0bd639f7dc11648b553cef85db6301aaf4f1"
   dependencies:
     eslint-plugin-prettier "^2.6.2"
 


### PR DESCRIPTION
It's stable enough to get a v1 release hurrah.

It looks like our plan is that dependencies that contain config are version locked to avoid potential games of whackamole if they add new rules, so I've done the same here.