### PR TITLE
Disable scss/no-duplicate-dollar-variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Disable `scss/no-duplicate-dollar-variables` rule by default. It makes no attempt to understand how Sass's variable scoping works which results in lots of false warnings on completely reasonable code. ([#44](https://github.com/Shopify/stylelint-config-shopify/pull/44))
 
 ## [7.0.1] - 2018-09-12
 

--- a/rules/scss.js
+++ b/rules/scss.js
@@ -66,8 +66,5 @@ module.exports = {
   // Disallow dollar variables within a stylesheet.
   'scss/no-dollar-variables': null,
   // Disallow duplicate dollar variables within a stylesheet.
-  'scss/no-duplicate-dollar-variables': [
-    true,
-    {ignoreInsideAtRules: ['if', 'mixin', 'function']},
-  ],
+  'scss/no-duplicate-dollar-variables': null,
 };


### PR DESCRIPTION
It makes no attempt to understand how sass's variable scoping works which
results in lots of false warnings on completely reasonable code.

For instance it complains about the following, despite it being totally reasonable:

```scss
@function foo() {
  @if true {
    $foo: 200;
  } @else {
    $bar: 400;
  }
}

@function bar() {
  @if true {
    $foo: 200;
  } @else {
    $bar: 900;
  }
}
```


See initial discussion at  https://github.com/Shopify/stylelint-config-shopify/pull/40#pullrequestreview-151139202