### PR TITLE
Bump stylelint peerDependency to 9.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- ## [Unreleased] -->
 
+- Raise `peerDependency` on `stylelint` to 9.4.0 to accomodate the `linebreaks` rule.
+
 ## [7.0.4] - 2018-10-02
 
 - Bump stylelint-prettier v1.0.3 to avoid a transitive dependency on eslint-plugin-prettier ([#45](https://github.com/Shopify/stylelint-config-shopify/pull/45))
@@ -227,7 +229,8 @@ property: <top> <right> <bottom> <left>
 * Initial release
 
 
-[Unreleased]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.3...HEAD
+[Unreleased]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.4...HEAD
+[7.0.4]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.3...v7.0.4
 [7.0.3]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.2...v7.0.3
 [7.0.2]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.1...v7.0.2
 [7.0.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.0...v7.0.1

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tape": "^4.9.1"
   },
   "peerDependencies": {
-    "stylelint": ">=9.1.1"
+    "stylelint": ">=9.4.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The v7 release of `stylelint-config-shopify` introduced the `linebreaks` rule (https://github.com/Shopify/stylelint-config-shopify/pull/40).

This rule was added in Stylelint 9.4.0 (https://github.com/stylelint/stylelint/pull/3289).

The existing `peerDependency` on stylelint is `>=9.1.1`, which doesn't have this rule and therefore breaks:

```
$ stylelint 'app/assets/stylesheets/**/*.scss'
Error: Undefined rule linebreaks
```

This PR raises the minimum version to 9.4.0 which includes the rule. This should flag to consumers that they have an outdated peer dependency when they upgrade their `stylelint-config-shopify` package and they can avoid the error 🎉 