### PR TITLE
Forbid `display: table` for VoiceOver compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Forbid `display: table` for better Safari + VoiceOver + iOS compatibility ([#52](https://github.com/Shopify/stylelint-config-shopify/pull/52))
 
 ## [7.2.1] - 2019-04-04
 

--- a/rules/declaration.js
+++ b/rules/declaration.js
@@ -44,6 +44,7 @@ module.exports = {
   // Specify a blacklist of disallowed property and value pairs within declarations.
   'declaration-property-value-blacklist': {
     '/^animation/': ['linear'],
+    display: ['table'],
   },
   // Specify a whitelist of allowed property and value pairs within declarations.
   'declaration-property-value-whitelist': {},


### PR DESCRIPTION
Per Scott Vinkle:

> :fire: Using CSS `display: table` for alignment incorrectly describes content as a `table` with Safari + VoiceOver on iOS specifically. Use Flexbox for content alignment and layout instead.